### PR TITLE
Add inter-route local search with Relocate, Swap, TwoOpt, Cross opera…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,13 @@ set(UTILS_SOURCES
 set(SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 set(SRC_SOURCES
         "${SRC_DIR}/first_step.cpp"
+        "${SRC_DIR}/inter_operation.cpp"
 )
 
+set(INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
 add_library(utils STATIC ${UTILS_SOURCES} ${SRC_SOURCES})
-target_include_directories(utils PUBLIC ${UTILS_DIR})
+target_include_directories(utils PUBLIC ${UTILS_DIR} ${INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(utils PUBLIC nlohmann_json::nlohmann_json)
 
 set(SOURCES main.cpp)
@@ -35,5 +38,6 @@ endif()
 
 option(SAVE_STEPS "save each 5 seconds" OFF)
 if (SAVE_STEPS)
+    add_definitions(-DCHECK_SWAPS)
     add_definitions(-DSAVE_STEPS)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,5 @@ endif()
 
 option(SAVE_STEPS "save each 5 seconds" OFF)
 if (SAVE_STEPS)
-    add_definitions(-DCHECK_SWAPS)
     add_definitions(-DSAVE_STEPS)
 endif()

--- a/include/first_step.hpp
+++ b/include/first_step.hpp
@@ -12,7 +12,7 @@
 struct FirstStepAnswer {
 
     using score_type = int64_t;
-    using points_type = InputData::points_type;
+    using points_type = TInputData::points_type;
     static constexpr score_type default_value = std::numeric_limits<score_type>::min() + 1;
 
     /// значение целевой функции
@@ -36,8 +36,8 @@ struct FirstStepAnswer {
     }
 };
 
-template<size_t bitset_size = std::numeric_limits<InputData::points_type>::max(), bool is_time_dependent = false>
-std::vector<FirstStepAnswer> DoFirstStep(const InputData &input);
+template<size_t bitset_size = std::numeric_limits<TInputData::points_type>::max(), bool is_time_dependent = false>
+std::vector<FirstStepAnswer> DoFirstStep(const TInputData &input);
 
 std::ostream &operator<<(std::ostream &os, const FirstStepAnswer &answer);
 

--- a/include/inter_operation.hpp
+++ b/include/inter_operation.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <functional>
+#include <random>
+#include <vector>
+
+#include "path.hpp"
+#include "../utils/problem_arguments.hpp"
+
+class TInterOperations {
+public:
+    enum class EOperation {
+        Relocate = 0,
+        Swap     = 1,
+        TwoOpt   = 2,
+        Cross    = 3,
+    };
+
+    void RunLocalSearch(std::vector<TPath>& paths,
+                        const TInputData&   inputData,
+                        int                 max_no_improvement);
+
+    struct RejectStats {
+        int vertex_limit = 0;   ///< заблокировано ограничением min/max вершин до перебора
+        int time_exceed  = 0;   ///< кандидат нарушил max_time
+        int dist_exceed  = 0;   ///< кандидат нарушил max_distance
+        int no_gain      = 0;   ///< кандидат допустим, но score не вырос
+    };
+
+private:
+    using TOperationFn = bool (TInterOperations::*)(TPath&, TPath&, const TInputData&, RejectStats&);
+
+    bool Relocate(TPath& path1, TPath& path2, const TInputData& inputData, RejectStats& stats);
+    bool Swap    (TPath& path1, TPath& path2, const TInputData& inputData, RejectStats& stats);
+    bool TwoOpt  (TPath& path1, TPath& path2, const TInputData& inputData, RejectStats& stats);
+    bool Cross   (TPath& path1, TPath& path2, const TInputData& inputData, RejectStats& stats);
+};

--- a/include/path.hpp
+++ b/include/path.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <ostream>
+
+#include "first_step.hpp"
+
+using TRoute = std::vector<FirstStepAnswer::points_type>;
+
+struct TPath {
+    using score_type = FirstStepAnswer::score_type;
+
+    TRoute tour;
+    int64_t distance{0};
+    int64_t time{0};
+    int64_t score{0};
+
+    int64_t max_distance{0};
+    int64_t max_time{0};
+    FirstStepAnswer::points_type max_vertexes{0};
+    FirstStepAnswer::points_type min_vertexes{0};
+    FirstStepAnswer::points_type depo{0};
+    uint32_t agent_idx{0};
+
+
+    bool operator==(const TPath &other) const {
+        if (tour.size() != other.tour.size()) {
+            return false;
+        }
+        if (time != other.time) {
+            return false;
+        }
+        if (distance != other.distance) {
+            return false;
+        }
+        if (score != other.score) {
+            return false;
+        }
+        for (size_t i = 0; i < tour.size(); ++i) {
+            if (tour[i] != other.tour[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    std::string get_data_to_csv() const {
+        return std::to_string(score) + "," + std::to_string(time) + "," + std::to_string(distance);
+    }
+
+};
+
+std::ostream& operator<<(std::ostream& os, const TPath& path);

--- a/main.cpp
+++ b/main.cpp
@@ -5,6 +5,7 @@
 #endif
 
 #include "include/first_step.hpp"
+#include "include/inter_operation.hpp"
 
 #include <iostream>
 #include <fstream>
@@ -15,14 +16,15 @@
 
 using Solution = std::vector<FirstStepAnswer>;
 
-Solution Solve(InputData &&input, const ProgramArguments& args) {
+
+Solution Solve(TInputData& input, const ProgramArguments& args) {
 
     std::vector<FirstStepAnswer> firstStepAnswers;
     firstStepAnswers.resize(input.agents_count);
 
     for (size_t i = 0; i < input.agents_count; ++i) {
         input.current_agent = i;
-        
+
         std::vector<FirstStepAnswer> result;
         if (input.points_count < 128) {
             result = DoFirstStep<128, true>(input);
@@ -31,22 +33,21 @@ Solution Solve(InputData &&input, const ProgramArguments& args) {
         } else if (input.points_count < 512) {
             result = DoFirstStep<512, true>(input);
         } else {
-            result = DoFirstStep<std::numeric_limits<InputData::points_type>::max(), true>(input);
+            result = DoFirstStep<std::numeric_limits<TInputData::points_type>::max(), true>(input);
         }
-        
+
         if (result.empty()) {
-            std::cout << "No solution for agent #" << i << std::endl;
+            std::cout << "No solution for agent #" << i << "\n";
             firstStepAnswers[i] = {};
             continue;
         }
-        
+
         firstStepAnswers[i] = result[0];
-        
+
         for (auto visited : firstStepAnswers[i].vertexes) {
             input.visited_points.insert(visited);
         }
     }
-
 
     return firstStepAnswers;
 }
@@ -57,17 +58,61 @@ int main(int argc, char *argv[]) {
         return -1;
     }
 
-    InputData input;
+    TInputData input;
     if (!JsonParser::ParseInputDataFromJson(args.problemJsonPath, input)) {
         return -2;
     }
 
     std::cout << input;
 
-    auto solutions = Solve(std::move(input), args);
-    for (size_t i = 0; i < input.agents_count; ++i) {
-        std::cout << "Path for agent: #" << i << "\t" << solutions[i] << "\n";
+    auto firstStepAnswers = Solve(input, args);
+
+    // строим TPath из результатов первого шага
+    // vertexes имеет вид [0 (депо), v1, v2, ..., vn, 0 (депо)] — обрезаем оба конца
+    std::vector<TPath> paths;
+    paths.reserve(firstStepAnswers.size());
+
+    for (uint32_t i = 0; i < firstStepAnswers.size(); ++i) {
+        auto& ans = firstStepAnswers[i];
+
+        TRoute route = std::move(ans.vertexes);
+        if (route.size() >= 2) {
+            route.erase(route.begin());  // убираем стартовый депо
+            route.pop_back();            // убираем финальный депо
+        } else {
+            route.clear();
+        }
+
+        paths.push_back(TPath{
+            .tour         = std::move(route),
+            .distance     = ans.distance,
+            .time         = ans.time,
+            .score        = ans.value,
+            .max_distance = input.max_distance[i],
+            .max_time     = input.max_time[i],
+            .max_vertexes = input.max_load[i],
+            .min_vertexes = input.min_load[i],
+            .depo         = 0,
+            .agent_idx    = i,
+        });
     }
+
+    auto print_paths = [&](const char* header) {
+        std::cout << "\n=== " << header << " ===\n";
+        int64_t total = 0;
+        for (size_t i = 0; i < paths.size(); ++i) {
+            std::cout << "Agent #" << i << "  " << paths[i];
+            total += paths[i].score;
+        }
+        std::cout << "Total score: " << total << "\n";
+    };
+
+    print_paths("First step results");
+
+    TInterOperations ops;
+
+    ops.RunLocalSearch(paths, input, args.meta.max_iter_without_solution);
+    print_paths("After local search");
 
     return 0;
 }

--- a/src/first_step.cpp
+++ b/src/first_step.cpp
@@ -110,7 +110,7 @@ namespace {
 }
 
 template<size_t bitset_size, bool is_time_dependent>
-std::vector<FirstStepAnswer> DoFirstStep(const InputData &input) {
+std::vector<FirstStepAnswer> DoFirstStep(const TInputData &input) {
 
     using score_type = FirstStepAnswer::score_type;
     using points_type = FirstStepAnswer::points_type;
@@ -257,13 +257,13 @@ std::ostream &operator<<(std::ostream &os, const FirstStepAnswer &answer) {
     return os;
 }
 
-template std::vector<FirstStepAnswer> DoFirstStep<128, true>(const InputData &input);
-template std::vector<FirstStepAnswer> DoFirstStep<256, true>(const InputData &input);
-template std::vector<FirstStepAnswer> DoFirstStep<512, true>(const InputData &input);
-template std::vector<FirstStepAnswer> DoFirstStep<std::numeric_limits<InputData::points_type>::max(), true>(const InputData &input);
+template std::vector<FirstStepAnswer> DoFirstStep<128, true>(const TInputData &input);
+template std::vector<FirstStepAnswer> DoFirstStep<256, true>(const TInputData &input);
+template std::vector<FirstStepAnswer> DoFirstStep<512, true>(const TInputData &input);
+template std::vector<FirstStepAnswer> DoFirstStep<std::numeric_limits<TInputData::points_type>::max(), true>(const TInputData &input);
 
 
-template std::vector<FirstStepAnswer> DoFirstStep<128, false>(const InputData &input);
-template std::vector<FirstStepAnswer> DoFirstStep<256, false>(const InputData &input);
-template std::vector<FirstStepAnswer> DoFirstStep<512, false>(const InputData &input);
-template std::vector<FirstStepAnswer> DoFirstStep<std::numeric_limits<InputData::points_type>::max(), false>(const InputData &input);
+template std::vector<FirstStepAnswer> DoFirstStep<128, false>(const TInputData &input);
+template std::vector<FirstStepAnswer> DoFirstStep<256, false>(const TInputData &input);
+template std::vector<FirstStepAnswer> DoFirstStep<512, false>(const TInputData &input);
+template std::vector<FirstStepAnswer> DoFirstStep<std::numeric_limits<TInputData::points_type>::max(), false>(const TInputData &input);

--- a/src/inter_operation.cpp
+++ b/src/inter_operation.cpp
@@ -1,0 +1,477 @@
+#include "../include/inter_operation.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+
+std::ostream& operator<<(std::ostream& os, const TPath& path) {
+    os << "score=" << std::setw(8) << path.score
+       << "  time=" << std::setw(8) << path.time
+       << "  dist=" << std::setw(8) << path.distance
+       << "  stops=" << path.tour.size() << "\n";
+    os << "  route: [depo]";
+    for (auto v : path.tour) {
+        os << " -> " << v;
+    }
+    os << " -> [depo]\n";
+    return os;
+}
+
+bool TInterOperations::Relocate(TPath& path1, TPath& path2, const TInputData &inputData, RejectStats& stats) {
+    auto initial_score = path1.score + path2.score;
+
+    struct best_operation {
+        bool from_first;
+        size_t from_idx;
+        size_t to_idx;
+        int64_t src_distance;
+        int64_t src_time;
+        int64_t src_score;
+        int64_t dst_distance;
+        int64_t dst_time;
+        int64_t dst_score;
+    };
+
+    bool found = false;
+    best_operation best_relocation{};
+
+    // src -> dst: пробуем переместить вершину из src в dst и ищем лучший вариант
+    auto try_relocate_direction = [&](TPath& src, TPath& dst, bool from_first) {
+        if (src.tour.size() <= src.min_vertexes || dst.tour.size() >= dst.max_vertexes) {
+            ++stats.vertex_limit;
+            return;
+        }
+
+        for (size_t from = 0; from < src.tour.size(); ++from) {
+            const auto element = src.tour[from];
+            src.tour.erase(src.tour.begin() + from);
+            auto [distance1, time1, score1] = inputData.get_path_distance_time_score(src);
+
+            for (size_t to = 0; to <= dst.tour.size(); ++to) {
+                dst.tour.insert(dst.tour.begin() + to, element);
+
+                auto [distance2, time2, score2] = inputData.get_path_distance_time_score(dst);
+
+                if (distance1 >= src.max_distance || distance2 >= dst.max_distance) {
+                    ++stats.dist_exceed;
+                } else if (time1 >= src.max_time || time2 >= dst.max_time) {
+                    ++stats.time_exceed;
+                } else if (score1 + score2 <= initial_score) {
+                    ++stats.no_gain;
+                } else {
+                    found = true;
+                    best_relocation = {
+                        .from_first   = from_first,
+                        .from_idx     = from,
+                        .to_idx       = to,
+                        .src_distance = distance1,
+                        .src_time     = time1,
+                        .src_score    = score1,
+                        .dst_distance = distance2,
+                        .dst_time     = time2,
+                        .dst_score    = score2,
+                    };
+                    initial_score = score1 + score2;
+                }
+
+                dst.tour.erase(dst.tour.begin() + to);
+            }
+
+            src.tour.insert(src.tour.begin() + from, element);
+        }
+    };
+
+    try_relocate_direction(path1, path2, true);
+    try_relocate_direction(path2, path1, false);
+
+    if (found) {
+        TPath& src = best_relocation.from_first ? path1 : path2;
+        TPath& dst = best_relocation.from_first ? path2 : path1;
+
+        const auto element = src.tour[best_relocation.from_idx];
+        src.tour.erase(src.tour.begin() + best_relocation.from_idx);
+        dst.tour.insert(dst.tour.begin() + best_relocation.to_idx, element);
+
+        src.distance = best_relocation.src_distance;
+        src.time = best_relocation.src_time;
+        src.score = best_relocation.src_score;
+        dst.distance = best_relocation.dst_distance;
+        dst.time = best_relocation.dst_time;
+        dst.score = best_relocation.dst_score;
+    }
+
+    return found;
+}
+
+bool TInterOperations::Swap(TPath& path1, TPath& path2, const TInputData &inputData, RejectStats& stats) {
+    auto initial_score = path1.score + path2.score;
+
+    struct best_operation {
+        size_t path1_idx;
+        int64_t distance1;
+        int64_t time1;
+        int64_t score1;
+        size_t path2_idx;
+        int64_t distance2;
+        int64_t time2;
+        int64_t score2;
+    };
+
+    bool found = false;
+    best_operation best_swap{};
+
+#ifdef DEBUG_SWAP
+    int debug_printed = 0;
+    int kDebugMaxPrint = 5;
+    std::cout << "[DebugSwap] path1: time=" << path1.time << "/" << path1.max_time
+              << "  slack=" << (path1.max_time - path1.time)
+              << "  path2: time=" << path2.time << "/" << path2.max_time
+              << "  slack=" << (path2.max_time - path2.time) << "\n";
+#endif
+
+    for (size_t path1_idx = 0; path1_idx < path1.tour.size(); ++path1_idx) {
+        for (size_t path2_idx = 0; path2_idx < path2.tour.size(); ++path2_idx) {
+
+            const auto v1 = path1.tour[path1_idx];
+            const auto v2 = path2.tour[path2_idx];
+
+            std::swap(path1.tour[path1_idx], path2.tour[path2_idx]);
+
+            auto [distance1, time1, score1] = inputData.get_path_distance_time_score(path1);
+            auto [distance2, time2, score2] = inputData.get_path_distance_time_score(path2);
+
+#ifdef DEBUG_SWAP
+                const auto slack1 = path1.max_time - path1.time;
+                const auto slack2 = path2.max_time - path2.time;
+                const char* reason = "OK";
+                if (distance1 >= path1.max_distance || distance2 >= path2.max_distance) reason = "dist_exceed";
+                else if (time1 >= path1.max_time || time2 >= path2.max_time)             reason = "time_exceed";
+                else if (score1 + score2 <= initial_score)                               reason = "no_gain";
+                if (debug_printed < kDebugMaxPrint || strcmp(reason, "OK") == 0) {
+                    std::cout << "[DebugSwap]   swap v1=" << v1 << "@pos" << path1_idx
+                              << " <-> v2=" << v2 << "@pos" << path2_idx
+                              << " | p1: " << path1.time << "->" << time1
+                              << " (slack было " << slack1 << ", стало " << (path1.max_time - time1) << ")"
+                              << " | p2: " << path2.time << "->" << time2
+                              << " (slack было " << slack2 << ", стало " << (path2.max_time - time2) << ")"
+                              << " | " << reason << "\n";
+                    ++debug_printed;
+                }
+#endif
+
+            if (distance1 >= path1.max_distance || distance2 >= path2.max_distance) {
+                ++stats.dist_exceed;
+            } else if (time1 >= path1.max_time || time2 >= path2.max_time) {
+                ++stats.time_exceed;
+            } else if (score1 + score2 <= initial_score) {
+                ++stats.no_gain;
+            } else {
+                found = true;
+                best_swap = {
+                    .path1_idx = path1_idx,
+                    .distance1 = distance1,
+                    .time1     = time1,
+                    .score1    = score1,
+                    .path2_idx = path2_idx,
+                    .distance2 = distance2,
+                    .time2     = time2,
+                    .score2    = score2,
+                };
+                initial_score = score1 + score2;
+            }
+
+            // возврат путей к исходному состоянию
+            std::swap(path1.tour[path1_idx], path2.tour[path2_idx]);
+        }
+    }
+
+    if (found) {
+        std::swap(path1.tour[best_swap.path1_idx], path2.tour[best_swap.path2_idx]);
+
+        path1.distance = best_swap.distance1;
+        path1.time = best_swap.time1;
+        path1.score = best_swap.score1;
+
+        path2.distance = best_swap.distance2;
+        path2.time = best_swap.time2;
+        path2.score = best_swap.score2;
+    }
+
+    return found;
+}
+
+bool TInterOperations::TwoOpt(TPath& path1, TPath& path2, const TInputData &inputData, RejectStats& stats) {
+    auto initial_score = path1.score + path2.score;
+
+    struct best_operation {
+        size_t split1;
+        size_t split2;
+        int64_t distance1;
+        int64_t time1;
+        int64_t score1;
+        int64_t distance2;
+        int64_t time2;
+        int64_t score2;
+    };
+
+    bool found = false;
+    best_operation best_two_opt{};
+
+    // split1 — позиция разреза в path1: хвост path1[split1..] уходит в path2
+    // split2 — позиция разреза в path2: хвост path2[split2..] уходит в path1
+    for (size_t split1 = 0; split1 <= path1.tour.size(); ++split1) {
+        for (size_t split2 = 0; split2 <= path2.tour.size(); ++split2) {
+
+            const size_t new_size1 = split1 + (path2.tour.size() - split2);
+            const size_t new_size2 = split2 + (path1.tour.size() - split1);
+
+            if (new_size1 < path1.min_vertexes || new_size1 > path1.max_vertexes ||
+                new_size2 < path2.min_vertexes || new_size2 > path2.max_vertexes) {
+                ++stats.vertex_limit;
+                continue;
+            }
+
+            TRoute new_tour1(path1.tour.begin(), path1.tour.begin() + split1);
+            new_tour1.insert(new_tour1.end(), path2.tour.begin() + split2, path2.tour.end());
+
+            TRoute new_tour2(path2.tour.begin(), path2.tour.begin() + split2);
+            new_tour2.insert(new_tour2.end(), path1.tour.begin() + split1, path1.tour.end());
+
+            std::swap(path1.tour, new_tour1);
+            std::swap(path2.tour, new_tour2);
+
+            auto [distance1, time1, score1] = inputData.get_path_distance_time_score(path1);
+            auto [distance2, time2, score2] = inputData.get_path_distance_time_score(path2);
+
+            // возврат к исходному состоянию
+            std::swap(path1.tour, new_tour1);
+            std::swap(path2.tour, new_tour2);
+
+            if (distance1 >= path1.max_distance || distance2 >= path2.max_distance) {
+                ++stats.dist_exceed;
+            } else if (time1 >= path1.max_time || time2 >= path2.max_time) {
+                ++stats.time_exceed;
+            } else if (score1 + score2 <= initial_score) {
+                ++stats.no_gain;
+            } else {
+                found = true;
+                best_two_opt = {
+                    .split1    = split1,
+                    .split2    = split2,
+                    .distance1 = distance1,
+                    .time1     = time1,
+                    .score1    = score1,
+                    .distance2 = distance2,
+                    .time2     = time2,
+                    .score2    = score2,
+                };
+                initial_score = score1 + score2;
+            }
+        }
+    }
+
+    if (found) {
+        TRoute new_tour1(path1.tour.begin(), path1.tour.begin() + best_two_opt.split1);
+        new_tour1.insert(new_tour1.end(), path2.tour.begin() + best_two_opt.split2, path2.tour.end());
+
+        TRoute new_tour2(path2.tour.begin(), path2.tour.begin() + best_two_opt.split2);
+        new_tour2.insert(new_tour2.end(), path1.tour.begin() + best_two_opt.split1, path1.tour.end());
+
+        path1.tour = std::move(new_tour1);
+        path2.tour = std::move(new_tour2);
+
+        path1.distance = best_two_opt.distance1;
+        path1.time     = best_two_opt.time1;
+        path1.score    = best_two_opt.score1;
+        path2.distance = best_two_opt.distance2;
+        path2.time     = best_two_opt.time2;
+        path2.score    = best_two_opt.score2;
+    }
+
+    return found;
+}
+
+bool TInterOperations::Cross(TPath& path1, TPath& path2, const TInputData &inputData, RejectStats& stats) {
+    auto initial_score = path1.score + path2.score;
+
+    // длина отрезка ограничена четвертью минимального из двух маршрутов
+    const size_t max_seg_len = std::min(path1.tour.size(), path2.tour.size()) / 4;
+    if (max_seg_len == 0) {
+        ++stats.vertex_limit;
+        return false;
+    }
+
+    struct best_operation {
+        size_t seg_len;
+        size_t start1;
+        size_t start2;
+        int64_t distance1;
+        int64_t time1;
+        int64_t score1;
+        int64_t distance2;
+        int64_t time2;
+        int64_t score2;
+    };
+
+    bool found = false;
+    best_operation best_cross{};
+
+    for (size_t seg_len = 1; seg_len <= max_seg_len; ++seg_len) {
+        for (size_t start1 = 0; start1 + seg_len <= path1.tour.size(); ++start1) {
+            for (size_t start2 = 0; start2 + seg_len <= path2.tour.size(); ++start2) {
+
+                std::swap_ranges(
+                    path1.tour.begin() + start1,
+                    path1.tour.begin() + start1 + seg_len,
+                    path2.tour.begin() + start2
+                );
+
+                auto [distance1, time1, score1] = inputData.get_path_distance_time_score(path1);
+                auto [distance2, time2, score2] = inputData.get_path_distance_time_score(path2);
+
+                // возврат к исходному состоянию
+                std::swap_ranges(
+                    path1.tour.begin() + start1,
+                    path1.tour.begin() + start1 + seg_len,
+                    path2.tour.begin() + start2
+                );
+
+                if (distance1 >= path1.max_distance || distance2 >= path2.max_distance) {
+                    ++stats.dist_exceed;
+                } else if (time1 >= path1.max_time || time2 >= path2.max_time) {
+                    ++stats.time_exceed;
+                } else if (score1 + score2 <= initial_score) {
+                    ++stats.no_gain;
+                } else {
+                    found = true;
+                    best_cross = {
+                        .seg_len   = seg_len,
+                        .start1    = start1,
+                        .start2    = start2,
+                        .distance1 = distance1,
+                        .time1     = time1,
+                        .score1    = score1,
+                        .distance2 = distance2,
+                        .time2     = time2,
+                        .score2    = score2,
+                    };
+                    initial_score = score1 + score2;
+                }
+            }
+        }
+    }
+
+    if (found) {
+        std::swap_ranges(
+            path1.tour.begin() + best_cross.start1,
+            path1.tour.begin() + best_cross.start1 + best_cross.seg_len,
+            path2.tour.begin() + best_cross.start2
+        );
+
+        path1.distance = best_cross.distance1;
+        path1.time     = best_cross.time1;
+        path1.score    = best_cross.score1;
+        path2.distance = best_cross.distance2;
+        path2.time     = best_cross.time2;
+        path2.score    = best_cross.score2;
+    }
+
+    return found;
+}
+
+void TInterOperations::RunLocalSearch(std::vector<TPath>& paths,
+                                      const TInputData&   inputData,
+                                      int                 max_no_improvement) {
+    assert(max_no_improvement > 0);
+
+    static constexpr TOperationFn kOperations[] = {
+        &TInterOperations::Relocate,
+        &TInterOperations::Swap,
+        &TInterOperations::TwoOpt,
+        &TInterOperations::Cross,
+    };
+    static constexpr const char* kOperationNames[] = {
+        "Relocate", "Swap", "TwoOpt", "Cross",
+    };
+    static constexpr int kOperationsCount = static_cast<int>(std::size(kOperations));
+
+    std::mt19937 rng{std::random_device{}()};
+    std::uniform_int_distribution<size_t> path_dist(0, paths.size() - 1);
+    std::uniform_int_distribution<int>    op_dist(0, kOperationsCount - 1);
+
+    int no_improvement_streak = 0;
+    int total_attempts        = 0;
+    int total_improvements    = 0;
+
+    // статистика улучшений по каждой операции
+    int op_improvements[kOperationsCount] = {};
+
+    std::cout << "[LocalSearch] start  total_score="
+              << [&] {
+                     int64_t s = 0;
+                     for (auto& p : paths) s += p.score;
+                     return s;
+                 }()
+              << "  K=" << max_no_improvement << "\n";
+
+    while (no_improvement_streak < max_no_improvement) {
+        size_t i = path_dist(rng);
+        size_t j = path_dist(rng);
+        while (j == i) {
+            j = path_dist(rng);
+        }
+
+        const int     op_idx      = op_dist(rng);
+        const int64_t score_before = paths[i].score + paths[j].score;
+
+        RejectStats stats{};
+        const bool improved = (this->*kOperations[op_idx])(paths[i], paths[j], inputData, stats);
+        ++total_attempts;
+
+        if (improved) {
+            const int64_t score_after = paths[i].score + paths[j].score;
+            const int64_t delta       = score_after - score_before;
+
+            ++total_improvements;
+            ++op_improvements[op_idx];
+            no_improvement_streak = 0;
+
+            std::cout << "[LocalSearch] #" << std::setw(4) << total_attempts
+                      << "  " << std::setw(8) << std::left << kOperationNames[op_idx] << std::right
+                      << "  agents=(" << i << "," << j << ")"
+                      << "  delta=" << std::showpos << delta << std::noshowpos
+                      << "  score_after=" << score_after
+                      << "  streak_reset\n";
+        } else {
+            ++no_improvement_streak;
+
+#ifdef DEBUG_LOCAL_SEARCH
+            std::cout << "[LocalSearch] #" << std::setw(4) << total_attempts
+                      << "  " << std::setw(8) << std::left << kOperationNames[op_idx] << std::right
+                      << "  agents=(" << i << "," << j << ")"
+                      << "  FAIL"
+                      << "  vertex_limit=" << stats.vertex_limit
+                      << "  time_exceed="  << stats.time_exceed
+                      << "  dist_exceed="  << stats.dist_exceed
+                      << "  no_gain="      << stats.no_gain
+                      << "  streak=" << no_improvement_streak << "/" << max_no_improvement << "\n";
+#endif        
+        }
+    }
+
+    // итоговая статистика
+    int64_t total_score = 0;
+    for (auto& p : paths) total_score += p.score;
+
+    std::cout << "[LocalSearch] done"
+              << "  attempts="    << total_attempts
+              << "  improvements=" << total_improvements
+              << "  total_score=" << total_score << "\n";
+    std::cout << "[LocalSearch] improvements by operation:\n";
+    for (int k = 0; k < kOperationsCount; ++k) {
+        std::cout << "    " << std::setw(8) << std::left << kOperationNames[k] << std::right
+                  << " : " << op_improvements[k] << "\n";
+    }
+}

--- a/src/inter_operation.cpp
+++ b/src/inter_operation.cpp
@@ -161,9 +161,9 @@ bool TInterOperations::Swap(TPath& path1, TPath& path2, const TInputData &inputD
                 }
 #endif
 
-            if (distance1 >= path1.max_distance || distance2 >= path2.max_distance) {
+            if (distance1 > path1.max_distance || distance2 > path2.max_distance) {
                 ++stats.dist_exceed;
-            } else if (time1 >= path1.max_time || time2 >= path2.max_time) {
+            } else if (time1 > path1.max_time || time2 > path2.max_time) {
                 ++stats.time_exceed;
             } else if (score1 + score2 <= initial_score) {
                 ++stats.no_gain;

--- a/src/inter_operation.cpp
+++ b/src/inter_operation.cpp
@@ -54,9 +54,9 @@ bool TInterOperations::Relocate(TPath& path1, TPath& path2, const TInputData &in
 
                 auto [distance2, time2, score2] = inputData.get_path_distance_time_score(dst);
 
-                if (distance1 >= src.max_distance || distance2 >= dst.max_distance) {
+                if (distance1 > src.max_distance || distance2 > dst.max_distance) {
                     ++stats.dist_exceed;
-                } else if (time1 >= src.max_time || time2 >= dst.max_time) {
+                } else if (time1 > src.max_time || time2 > dst.max_time) {
                     ++stats.time_exceed;
                 } else if (score1 + score2 <= initial_score) {
                     ++stats.no_gain;

--- a/src/inter_operation.cpp
+++ b/src/inter_operation.cpp
@@ -249,9 +249,9 @@ bool TInterOperations::TwoOpt(TPath& path1, TPath& path2, const TInputData &inpu
             std::swap(path1.tour, new_tour1);
             std::swap(path2.tour, new_tour2);
 
-            if (distance1 >= path1.max_distance || distance2 >= path2.max_distance) {
+            if (distance1 > path1.max_distance || distance2 > path2.max_distance) {
                 ++stats.dist_exceed;
-            } else if (time1 >= path1.max_time || time2 >= path2.max_time) {
+            } else if (time1 > path1.max_time || time2 > path2.max_time) {
                 ++stats.time_exceed;
             } else if (score1 + score2 <= initial_score) {
                 ++stats.no_gain;

--- a/src/inter_operation.cpp
+++ b/src/inter_operation.cpp
@@ -386,6 +386,10 @@ void TInterOperations::RunLocalSearch(std::vector<TPath>& paths,
                                       int                 max_no_improvement) {
     assert(max_no_improvement > 0);
 
+    if (paths.size() < 2) {
+        return;
+    }
+
     static constexpr TOperationFn kOperations[] = {
         &TInterOperations::Relocate,
         &TInterOperations::Swap,

--- a/src/inter_operation.cpp
+++ b/src/inter_operation.cpp
@@ -338,9 +338,9 @@ bool TInterOperations::Cross(TPath& path1, TPath& path2, const TInputData &input
                     path2.tour.begin() + start2
                 );
 
-                if (distance1 >= path1.max_distance || distance2 >= path2.max_distance) {
+                if (distance1 > path1.max_distance || distance2 > path2.max_distance) {
                     ++stats.dist_exceed;
-                } else if (time1 >= path1.max_time || time2 >= path2.max_time) {
+                } else if (time1 > path1.max_time || time2 > path2.max_time) {
                     ++stats.time_exceed;
                 } else if (score1 + score2 <= initial_score) {
                     ++stats.no_gain;

--- a/utils/json_parser.cpp
+++ b/utils/json_parser.cpp
@@ -3,7 +3,7 @@
 #include "json_parser.hpp"
 
 namespace nlohmann {
-    inline void from_json(const json &j, InputData &t) {
+    inline void from_json(const json &j, TInputData &t) {
         j.at("points_count").get_to(t.points_count);
         j.at("start_time").get_to(t.agent_start_time);
         j.at("agents_count").get_to(t.agents_count);
@@ -50,7 +50,7 @@ namespace JsonParser {
 
     using json = nlohmann::json;
 
-    bool ParseInputDataFromJson(const std::string &jsonPath, InputData &arg) {
+    bool ParseInputDataFromJson(const std::string &jsonPath, TInputData &arg) {
         std::ifstream jsonFile(jsonPath);
         if (!jsonFile) {
             std::cerr << "Can`t open input file with problem" << std::endl;
@@ -60,7 +60,7 @@ namespace JsonParser {
         json j;
         jsonFile >> j;
 
-        arg = j.get<InputData>();
+        arg = j.get<TInputData>();
         return true;
     }
 

--- a/utils/json_parser.hpp
+++ b/utils/json_parser.hpp
@@ -4,7 +4,7 @@
 #include <nlohmann/json.hpp>
 
 namespace JsonParser {
-    bool ParseInputDataFromJson(const std::string &jsonPath, InputData &arg);
+    bool ParseInputDataFromJson(const std::string &jsonPath, TInputData &arg);
 
     bool ParseSolutionFromJson(const std::string &jsonPath, OutData& solution);
 

--- a/utils/problem_arguments.cpp
+++ b/utils/problem_arguments.cpp
@@ -1,4 +1,5 @@
 #include "problem_arguments.hpp"
+#include "../include/path.hpp"
 #include <unistd.h>
 #include <ostream>
 
@@ -85,14 +86,10 @@ bool ParseProgramArguments(int argc, char *argv[], ProgramArguments &args) {
     return true;
 }
 
-int64_t InputData::get_time_dependent_cost(int64_t time,
-                                           InputData::points_type from,
-                                           InputData::points_type to) const {
+int64_t TInputData::get_time_dependent_cost(int64_t time,
+                                           TInputData::points_type from,
+                                           TInputData::points_type to) const {
 
-    if (is_mapped) {
-        from = from_new_to_old.at(from);
-        to = from_new_to_old.at(to);
-    }
                                             
     if (time >= time_duration * (time_matrix.size() - 1)) {
         return time_matrix[time_matrix.size() - 1][from][to];
@@ -106,46 +103,39 @@ int64_t InputData::get_time_dependent_cost(int64_t time,
 }
 
 std::tuple<int64_t, int64_t, int64_t>
-InputData::get_path_time_distance_score(const std::vector<InputData::points_type> &path) const {
+TInputData::get_path_distance_time_score(const TPath& path) const {
 
-    if (path.size() <= 2) {
-        return std::make_tuple(0, 0, 0);
+    if (path.tour.empty()) {
+        return {0, 0, 0};
     }
 
     int64_t distance = 0;
     int64_t time = 0;
     int64_t score = 0;
 
-    // считаем время и дистанцию с учетом времени обслуживания точек
-    // i -> i + 1
-    // 0 -> 1
-    // 1 -> 2
-    // ...
-    // n -> 0
-    points_type from = 0, to = 0;
-    for (size_t i = 0; i < path.size() - 1; ++i) {
+    const auto depo = path.depo;
 
-        if (is_mapped) {
-            from = from_new_to_old.at(path[i]);
-            to = from_new_to_old.at(path[i + 1]);
+    points_type from = depo, to = 0;
+    for (size_t i = 0; i < path.tour.size() + 1; ++i) {
+        
+        if (i == path.tour.size()) [[unlikely]] {
+            to = depo;
         } else {
-            from = path[i];
-            to = path[i + 1];
+            to = path.tour[i];
         }
 
         distance += distance_matrix[from][to];
-        // функция сама сделает маппинг если is_mapped
-        auto travel_time = get_time_dependent_cost(time + agent_start_time[current_agent], path[i], path[i + 1]);
+        auto travel_time = get_time_dependent_cost(time + agent_start_time[path.agent_idx], from, to);
+        time += (to == depo ? 0 : point_service_times[to - 1]) + travel_time;
+        score += (to == depo ? 0 : point_scores[to - 1]) - travel_time;
 
-        time += (to == 0 ? 0 : point_service_times[to - 1]) + travel_time;
-        // point_scores - свдинуты на 1 индекс, т.к. 0 - депо
-        score += (to == 0 ? 0 : point_scores[to - 1]) - travel_time;
+        from = to;
     }
 
     return std::make_tuple(distance, time, score);
 }
 
-std::ostream &operator<<(std::ostream &os, const InputData &data) {
+std::ostream &operator<<(std::ostream &os, const TInputData &data) {
     os << "points_count: " << data.points_count << "\n";
 
     os << "Agents info:\n";

--- a/utils/problem_arguments.hpp
+++ b/utils/problem_arguments.hpp
@@ -6,6 +6,8 @@
 #include <map>
 #include <unordered_set>
 
+struct TPath;
+
 struct MetaParameters {
     int population_size;
     int alpha;
@@ -29,7 +31,7 @@ struct ProgramArguments {
 
 bool ParseProgramArguments(int argc, char *argv[], ProgramArguments &args);
 
-struct InputData {
+struct TInputData {
     using points_type = uint16_t;
     /// количество точек в задаче, включая склад.
     points_type points_count{};
@@ -63,7 +65,7 @@ struct InputData {
 
     [[nodiscard]] int64_t get_time_dependent_cost(int64_t time, points_type from, points_type to) const;
 
-    [[nodiscard]] std::tuple<int64_t, int64_t, int64_t> get_path_time_distance_score(const std::vector<points_type> &path) const;
+    [[nodiscard]] std::tuple<int64_t, int64_t, int64_t> get_path_distance_time_score(const TPath& path) const;
 
     std::map<points_type, points_type> from_new_to_old{};
 
@@ -73,10 +75,10 @@ struct InputData {
     bool is_mapped = false;
 };
 
-std::ostream &operator<<(std::ostream &os, const InputData &data);
+std::ostream &operator<<(std::ostream &os, const TInputData &data);
 
 struct OutData {
-    using points_type = InputData::points_type;
+    using points_type = TInputData::points_type;
     /// последовательность индексов точек, составляющих найденный маршрут.
     std::vector<points_type> route;
     /// количество точек в решении.


### PR DESCRIPTION

- Add TPath struct with agent_idx for correct per-agent time computation
- Add TInterOperations: Relocate, Swap, TwoOpt, Cross inter-route operations
- Add RunLocalSearch with streak-based termination
- Add CheckAllSwaps diagnostic for exhaustive swap analysis
- Fix get_path_distance_time_score to use path.agent_idx instead of current_agent
- Fix Swap debug prints (time1/time2 copy-paste bug)
- Update CMakeLists.txt, main.cpp and all utils accordingly
